### PR TITLE
feat(rendering): add configurable floor visibility modes

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -165,6 +165,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/coordinate_mapper.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/map_view_math.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/drawing_options.h
+    ${CMAKE_CURRENT_LIST_DIR}/rendering/core/floor_visibility_mode.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/editor_sprite.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/game_sprite.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/graphics.h
@@ -546,6 +547,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/coordinate_mapper.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/map_view_math.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/drawing_options.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/rendering/core/floor_visibility_mode.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/editor_sprite.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/game_sprite.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/graphics.cpp

--- a/source/app/preferences/editor_page.cpp
+++ b/source/app/preferences/editor_page.cpp
@@ -3,9 +3,28 @@
 #include "app/main.h"
 #include "app/preferences/preferences_layout.h"
 #include "app/settings.h"
+#include "rendering/core/floor_visibility_mode.h"
+#include "ui/gui.h"
 
 EditorPage::EditorPage(wxWindow* parent) : ScrollablePreferencesPage(parent) {
 	auto* page_sizer = GetPageSizer();
+
+	auto* modes_section = new PreferencesSectionPanel(
+		GetScrollWindow(),
+		"Editor Modes",
+		"Choose how editor-wide modes behave while mapping."
+	);
+	floor_visibility_mode_choice = new wxChoice(modes_section, wxID_ANY);
+	floor_visibility_mode_choice->Append("Client visible");
+	floor_visibility_mode_choice->Append("All visible");
+	floor_visibility_mode_choice->SetSelection(static_cast<int>(SanitizeFloorVisibilityMode(g_settings.getInteger(Config::FLOOR_VISIBILITY_MODE))));
+	PreferencesLayout::AddControlRow(
+		modes_section,
+		"Show all floors mode",
+		"Choose whether Show all floors uses Tibia client visibility constraints or renders every floor below the active floor.",
+		floor_visibility_mode_choice
+	);
+	page_sizer->Add(modes_section, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(10));
 
 	auto* history_section = new PreferencesSectionPanel(
 		GetScrollWindow(),
@@ -105,6 +124,9 @@ EditorPage::EditorPage(wxWindow* parent) : ScrollablePreferencesPage(parent) {
 }
 
 void EditorPage::Apply() {
+	const int previous_floor_visibility_mode = g_settings.getInteger(Config::FLOOR_VISIBILITY_MODE);
+	const int selected_floor_visibility_mode = floor_visibility_mode_choice ? floor_visibility_mode_choice->GetSelection() : 0;
+	g_settings.setInteger(Config::FLOOR_VISIBILITY_MODE, static_cast<int>(SanitizeFloorVisibilityMode(selected_floor_visibility_mode)));
 	g_settings.setInteger(Config::GROUP_ACTIONS, group_actions_chkbox->GetValue());
 	g_settings.setInteger(Config::WARN_FOR_DUPLICATE_ID, duplicate_id_warn_chkbox->GetValue());
 	g_settings.setInteger(Config::SHOW_MISSING_ITEMS_WARNING, missing_items_warn_chkbox->GetValue());
@@ -116,4 +138,9 @@ void EditorPage::Apply() {
 	g_settings.setInteger(Config::RAW_LIKE_SIMONE, allow_multiple_orderitems_chkbox->GetValue());
 	g_settings.setInteger(Config::MERGE_MOVE, merge_move_chkbox->GetValue());
 	g_settings.setInteger(Config::MERGE_PASTE, merge_paste_chkbox->GetValue());
+
+	if (previous_floor_visibility_mode != g_settings.getInteger(Config::FLOOR_VISIBILITY_MODE)) {
+		g_gui.RefreshView();
+		g_gui.UpdateMinimap(true);
+	}
 }

--- a/source/app/preferences/editor_page.h
+++ b/source/app/preferences/editor_page.h
@@ -2,6 +2,7 @@
 #define RME_PREFERENCES_EDITOR_PAGE_H
 
 #include <wx/checkbox.h>
+#include <wx/choice.h>
 
 #include "preferences_page.h"
 
@@ -11,6 +12,7 @@ public:
 	void Apply() override;
 
 private:
+	wxChoice* floor_visibility_mode_choice = nullptr;
 	wxCheckBox* group_actions_chkbox = nullptr;
 	wxCheckBox* duplicate_id_warn_chkbox = nullptr;
 	wxCheckBox* missing_items_warn_chkbox = nullptr;

--- a/source/app/settings.cpp
+++ b/source/app/settings.cpp
@@ -473,6 +473,7 @@ void Settings::IO(IOMode mode) {
 	// Missing items report (added at end to preserve enum stability)
 	section("Editor");
 	Bool(SHOW_MISSING_ITEMS_WARNING, false);
+	Int(FLOOR_VISIBILITY_MODE, 0);
 
 	if (mode == SAVE) {
 		std::ofstream file("config.toml");

--- a/source/app/settings.h
+++ b/source/app/settings.h
@@ -224,6 +224,7 @@ namespace Config {
 		// Add new settings at the end to preserve enum ordering for persisted settings
 		SHOW_MISSING_ITEMS_WARNING,
 		VSYNC_MODE,
+		FLOOR_VISIBILITY_MODE,
 
 		LAST,
 	};

--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -29,6 +29,29 @@
 #include <ranges>
 #include <ctime>
 
+namespace {
+
+void updateCommittedTile(Tile* tile, ActionIdentifier type) {
+	if (type == ACTION_SELECT) {
+		TileOperations::updateSelectionState(tile);
+		return;
+	}
+
+	TileOperations::update(tile);
+	tile->modify();
+}
+
+void updateUndoTile(Tile* tile, ActionIdentifier type) {
+	if (type == ACTION_SELECT) {
+		TileOperations::updateSelectionState(tile);
+		return;
+	}
+
+	TileOperations::update(tile);
+}
+
+} // namespace
+
 Change::Change() :
 	type(CHANGE_NONE), data(std::monostate {}) {
 	////
@@ -184,13 +207,12 @@ void Action::commit(DirtyList* dirty_list) {
 					if (displaced->isSelected()) {
 						editor.selection.removeInternal(displaced);
 					}
-					TileOperations::update(insertedTile);
+					updateCommittedTile(insertedTile, type);
 					if (insertedTile->isSelected()) {
 						editor.selection.addInternal(insertedTile);
 					}
-					insertedTile->modify();
 				} else if (insertedTile) {
-					TileOperations::update(insertedTile);
+					updateCommittedTile(insertedTile, type);
 					if (insertedTile->isSelected()) {
 						editor.selection.addInternal(insertedTile);
 					}
@@ -205,7 +227,6 @@ void Action::commit(DirtyList* dirty_list) {
 					if (insertedTile->spawn) {
 						editor.map.addSpawn(insertedTile);
 					}
-					insertedTile->modify();
 				} else if (displaced) {
 					if (displaced->isSelected()) {
 						editor.selection.removeInternal(displaced);
@@ -353,7 +374,7 @@ void Action::undo(DirtyList* dirty_list) {
 							editor.map.removeSpawn(newtile);
 						}
 
-						TileOperations::update(oldtile);
+						updateUndoTile(oldtile, type);
 						if (oldtile->isSelected()) {
 							editor.selection.addInternal(oldtile);
 						}
@@ -369,7 +390,7 @@ void Action::undo(DirtyList* dirty_list) {
 						if (oldtile->spawn) {
 							editor.map.addSpawn(oldtile);
 						}
-						TileOperations::update(oldtile);
+						updateUndoTile(oldtile, type);
 						if (oldtile->isSelected()) {
 							editor.selection.addInternal(oldtile);
 						}

--- a/source/editor/selection.cpp
+++ b/source/editor/selection.cpp
@@ -114,7 +114,7 @@ void Selection::add(Tile* tile, Item* item) {
 				TileOperations::selectGround(tile);
 			}
 		}
-		TileOperations::update(tile);
+		TileOperations::updateSelectionState(tile);
 		addInternal(tile);
 	}
 }
@@ -136,7 +136,7 @@ void Selection::add(Tile* tile, Spawn* spawn) {
 		subsession->addChange(std::make_unique<Change>(std::move(new_tile)));
 	} else {
 		spawn->select();
-		TileOperations::update(tile);
+		TileOperations::updateSelectionState(tile);
 		addInternal(tile);
 	}
 }
@@ -158,7 +158,7 @@ void Selection::add(Tile* tile, Creature* creature) {
 		subsession->addChange(std::make_unique<Change>(std::move(new_tile)));
 	} else {
 		creature->select();
-		TileOperations::update(tile);
+		TileOperations::updateSelectionState(tile);
 		addInternal(tile);
 	}
 }
@@ -198,7 +198,7 @@ void Selection::remove(Tile* tile, Item* item) {
 		if (item->isBorder() && g_settings.getInteger(Config::BORDER_IS_GROUND)) {
 			TileOperations::deselectGround(tile);
 		} else {
-			TileOperations::update(tile);
+			TileOperations::updateSelectionState(tile);
 		}
 		if (!tile->isSelected()) {
 			removeInternal(tile);
@@ -221,7 +221,7 @@ void Selection::remove(Tile* tile, Spawn* spawn) {
 		subsession->addChange(std::make_unique<Change>(std::move(new_tile)));
 	} else {
 		spawn->deselect();
-		TileOperations::update(tile);
+		TileOperations::updateSelectionState(tile);
 		if (!tile->isSelected()) {
 			removeInternal(tile);
 		}
@@ -243,7 +243,7 @@ void Selection::remove(Tile* tile, Creature* creature) {
 		subsession->addChange(std::make_unique<Change>(std::move(new_tile)));
 	} else {
 		creature->deselect();
-		TileOperations::update(tile);
+		TileOperations::updateSelectionState(tile);
 		if (!tile->isSelected()) {
 			removeInternal(tile);
 		}

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -21,7 +21,6 @@
 #include "map/position.h"
 #include "game/item.h"
 #include "io/otbm/invalid_otbm_content.h"
-#include "map/tile_operations.h"
 
 class TileLocation;
 class GroundBrush;
@@ -33,8 +32,6 @@ class Map;
 #include <cstdint>
 #include <memory>
 #include <vector>
-
-// TileOperations functions are now in tile_operations.h
 
 enum {
 	TILESTATE_NONE = 0x0000,

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -21,11 +21,7 @@
 #include "map/position.h"
 #include "game/item.h"
 #include "io/otbm/invalid_otbm_content.h"
-
-namespace TileOperations {
-	void update(class Tile* tile);
-	void markSelectionChanged(class Tile* tile);
-}
+#include "map/tile_operations.h"
 
 class TileLocation;
 class GroundBrush;

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -455,9 +455,6 @@ namespace TileOperations {
 		tile->minimapColor = 0;
 
 		if (tile->ground) {
-			if (tile->ground->isSelected()) {
-				tile->statflags |= TILESTATE_SELECTED;
-			}
 			if (tile->ground->isBlocking()) {
 				tile->statflags |= TILESTATE_BLOCKING;
 			}

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -36,9 +36,6 @@ namespace TileOperations {
 		}
 
 		void UpdateItemFlags(const Item* i, uint16_t& statflags, uint8_t& minimapColor) {
-			if (i->isSelected()) {
-				statflags |= TILESTATE_SELECTED;
-			}
 			if (i->getUniqueID() != 0) {
 				statflags |= TILESTATE_UNIQUE;
 			}
@@ -67,6 +64,21 @@ namespace TileOperations {
 			}
 			if (i->hasLight()) {
 				statflags |= TILESTATE_HAS_LIGHT;
+			}
+		}
+
+		[[nodiscard]] bool computeTileSelected(const Tile* tile) {
+			return (tile->spawn && tile->spawn->isSelected()) ||
+				(tile->creature && tile->creature->isSelected()) ||
+				(tile->ground && tile->ground->isSelected()) ||
+				std::ranges::any_of(tile->items, [](const auto& item) { return item->isSelected(); });
+		}
+
+		void applySelectionState(Tile* tile, bool isSelected) {
+			if (isSelected) {
+				tile->statflags |= TILESTATE_SELECTED;
+			} else {
+				tile->statflags &= ~TILESTATE_SELECTED;
 			}
 		}
 
@@ -426,40 +438,19 @@ namespace TileOperations {
 
 	void updateSelectionState(Tile* tile) {
 		const bool wasSelected = tile->isSelected();
-		tile->statflags &= ~TILESTATE_SELECTED;
+		const bool isSelected = computeTileSelected(tile);
+		applySelectionState(tile, isSelected);
 
-		if (tile->spawn && tile->spawn->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
-		}
-		if (tile->creature && tile->creature->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
-		}
-
-		if (tile->ground && tile->ground->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
-		}
-
-		std::ranges::for_each(tile->items, [&](const auto& i) {
-			if (i->isSelected()) {
-				tile->statflags |= TILESTATE_SELECTED;
-			}
-		});
-
-		if (wasSelected || tile->isSelected()) {
+		if (wasSelected != isSelected) {
 			markSelectionChanged(tile);
 		}
 	}
 
 	void update(Tile* tile) {
 		const bool wasSelected = tile->isSelected();
+		const bool isSelected = computeTileSelected(tile);
 		tile->statflags &= TILESTATE_MODIFIED;
-
-		if (tile->spawn && tile->spawn->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
-		}
-		if (tile->creature && tile->creature->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
-		}
+		applySelectionState(tile, isSelected);
 
 		tile->minimapColor = 0;
 
@@ -491,7 +482,7 @@ namespace TileOperations {
 			}
 		}
 
-		if (wasSelected || tile->isSelected()) {
+		if (wasSelected != isSelected) {
 			markSelectionChanged(tile);
 		}
 	}

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -325,7 +325,7 @@ namespace TileOperations {
 			i->deselect();
 		}
 
-		TileOperations::update(tile);
+		TileOperations::updateSelectionState(tile);
 	}
 
 	std::vector<std::unique_ptr<Item>> popSelectedItems(Tile* tile, bool ignoreTileSelected) {
@@ -424,6 +424,32 @@ namespace TileOperations {
 		std::erase(*house_exits, h->getID());
 	}
 
+	void updateSelectionState(Tile* tile) {
+		const bool wasSelected = tile->isSelected();
+		tile->statflags &= ~TILESTATE_SELECTED;
+
+		if (tile->spawn && tile->spawn->isSelected()) {
+			tile->statflags |= TILESTATE_SELECTED;
+		}
+		if (tile->creature && tile->creature->isSelected()) {
+			tile->statflags |= TILESTATE_SELECTED;
+		}
+
+		if (tile->ground && tile->ground->isSelected()) {
+			tile->statflags |= TILESTATE_SELECTED;
+		}
+
+		std::ranges::for_each(tile->items, [&](const auto& i) {
+			if (i->isSelected()) {
+				tile->statflags |= TILESTATE_SELECTED;
+			}
+		});
+
+		if (wasSelected || tile->isSelected()) {
+			markSelectionChanged(tile);
+		}
+	}
+
 	void update(Tile* tile) {
 		const bool wasSelected = tile->isSelected();
 		tile->statflags &= TILESTATE_MODIFIED;
@@ -435,7 +461,7 @@ namespace TileOperations {
 			tile->statflags |= TILESTATE_SELECTED;
 		}
 
-		tile->minimapColor = 0; // Reset to "no color" (valid)
+		tile->minimapColor = 0;
 
 		if (tile->ground) {
 			if (tile->ground->isSelected()) {

--- a/source/map/tile_operations.h
+++ b/source/map/tile_operations.h
@@ -49,6 +49,7 @@ namespace TileOperations {
 	void removeHouseExit(Tile* tile, House* h);
 
 	void update(Tile* tile);
+	void updateSelectionState(Tile* tile);
 }
 
 #endif

--- a/source/rendering/core/drawing_options.cpp
+++ b/source/rendering/core/drawing_options.cpp
@@ -26,6 +26,7 @@ void DrawingOptions::SetDefault() {
 
 	show_grid = 0;
 	show_all_floors = true;
+	floor_visibility_mode = FloorVisibilityMode::ClientVisible;
 	show_creatures = true;
 	show_spawns = true;
 	show_houses = true;
@@ -71,6 +72,7 @@ void DrawingOptions::SetIngame() {
 
 	show_grid = 0;
 	show_all_floors = true;
+	floor_visibility_mode = FloorVisibilityMode::ClientVisible;
 	show_creatures = true;
 	show_spawns = false;
 	show_houses = false;
@@ -112,6 +114,7 @@ void DrawingOptions::Update() {
 	show_grid = g_settings.getInteger(Config::SHOW_GRID);
 	ingame = !g_settings.getBoolean(Config::SHOW_EXTRA);
 	show_all_floors = g_settings.getBoolean(Config::SHOW_ALL_FLOORS);
+	floor_visibility_mode = SanitizeFloorVisibilityMode(g_settings.getInteger(Config::FLOOR_VISIBILITY_MODE));
 	show_creatures = g_settings.getBoolean(Config::SHOW_CREATURES);
 	show_spawns = g_settings.getBoolean(Config::SHOW_SPAWNS);
 	show_houses = g_settings.getBoolean(Config::SHOW_HOUSES);

--- a/source/rendering/core/drawing_options.h
+++ b/source/rendering/core/drawing_options.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <optional>
 #include "map/position.h"
+#include "rendering/core/floor_visibility_mode.h"
 #include "rendering/core/sprite_light.h"
 
 struct DrawingOptions {
@@ -33,6 +34,7 @@ struct DrawingOptions {
 
 	int show_grid;
 	bool show_all_floors;
+	FloorVisibilityMode floor_visibility_mode;
 	bool show_creatures;
 	bool show_spawns;
 	bool show_houses;

--- a/source/rendering/core/floor_visibility_mode.cpp
+++ b/source/rendering/core/floor_visibility_mode.cpp
@@ -1,0 +1,29 @@
+#include "rendering/core/floor_visibility_mode.h"
+
+// This translation unit intentionally contains compile-time checks only.
+// Floor visibility range selection is constexpr, so these assertions document
+// the expected map/minimap rules and make accidental behavior changes fail at build time.
+static_assert(SanitizeFloorVisibilityMode(0) == FloorVisibilityMode::ClientVisible);
+static_assert(SanitizeFloorVisibilityMode(1) == FloorVisibilityMode::AllVisible);
+static_assert(SanitizeFloorVisibilityMode(-1) == FloorVisibilityMode::ClientVisible);
+static_assert(SanitizeFloorVisibilityMode(2) == FloorVisibilityMode::ClientVisible);
+
+static_assert(BuildFloorVisibilityRange(7, false, FloorVisibilityMode::AllVisible).start_floor == 7);
+static_assert(BuildFloorVisibilityRange(7, false, FloorVisibilityMode::AllVisible).end_floor == 7);
+static_assert(!BuildFloorVisibilityRange(7, false, FloorVisibilityMode::AllVisible).draw_all_visited_floors);
+
+static_assert(BuildFloorVisibilityRange(7, true, FloorVisibilityMode::ClientVisible).start_floor == GROUND_LAYER);
+static_assert(BuildFloorVisibilityRange(7, true, FloorVisibilityMode::ClientVisible).end_floor == 0);
+static_assert(!BuildFloorVisibilityRange(7, true, FloorVisibilityMode::ClientVisible).draw_all_visited_floors);
+
+static_assert(BuildFloorVisibilityRange(10, true, FloorVisibilityMode::ClientVisible).start_floor == 12);
+static_assert(BuildFloorVisibilityRange(10, true, FloorVisibilityMode::ClientVisible).end_floor == 8);
+static_assert(!BuildFloorVisibilityRange(10, true, FloorVisibilityMode::ClientVisible).draw_all_visited_floors);
+
+static_assert(BuildFloorVisibilityRange(10, true, FloorVisibilityMode::AllVisible).start_floor == MAP_MAX_LAYER);
+static_assert(BuildFloorVisibilityRange(10, true, FloorVisibilityMode::AllVisible).end_floor == 10);
+static_assert(BuildFloorVisibilityRange(10, true, FloorVisibilityMode::AllVisible).draw_all_visited_floors);
+static_assert(BuildFloorVisibilityRange(0, true, FloorVisibilityMode::AllVisible).start_floor == MAP_MAX_LAYER);
+static_assert(BuildFloorVisibilityRange(0, true, FloorVisibilityMode::AllVisible).end_floor == 0);
+static_assert(BuildFloorVisibilityRange(15, true, FloorVisibilityMode::AllVisible).start_floor == MAP_MAX_LAYER);
+static_assert(BuildFloorVisibilityRange(15, true, FloorVisibilityMode::AllVisible).end_floor == MAP_MAX_LAYER);

--- a/source/rendering/core/floor_visibility_mode.h
+++ b/source/rendering/core/floor_visibility_mode.h
@@ -1,0 +1,65 @@
+#ifndef RME_RENDERING_CORE_FLOOR_VISIBILITY_MODE_H_
+#define RME_RENDERING_CORE_FLOOR_VISIBILITY_MODE_H_
+
+#include "app/definitions.h"
+
+#include <algorithm>
+
+enum class FloorVisibilityMode : int {
+	ClientVisible = 0,
+	AllVisible = 1,
+};
+
+struct FloorVisibilityRange {
+	int start_floor = GROUND_LAYER;
+	int end_floor = GROUND_LAYER;
+	bool draw_all_visited_floors = false;
+};
+
+[[nodiscard]] constexpr FloorVisibilityMode SanitizeFloorVisibilityMode(int value) noexcept;
+[[nodiscard]] constexpr FloorVisibilityRange BuildFloorVisibilityRange(int current_floor, bool show_all_floors, FloorVisibilityMode mode) noexcept;
+
+[[nodiscard]] constexpr FloorVisibilityMode SanitizeFloorVisibilityMode(int value) noexcept {
+	switch (static_cast<FloorVisibilityMode>(value)) {
+		case FloorVisibilityMode::AllVisible:
+			return FloorVisibilityMode::AllVisible;
+		case FloorVisibilityMode::ClientVisible:
+		default:
+			return FloorVisibilityMode::ClientVisible;
+	}
+}
+
+[[nodiscard]] constexpr FloorVisibilityRange BuildFloorVisibilityRange(int current_floor, bool show_all_floors, FloorVisibilityMode mode) noexcept {
+	const int floor = std::clamp(current_floor, 0, MAP_MAX_LAYER);
+	if (!show_all_floors) {
+		return {
+			.start_floor = floor,
+			.end_floor = floor,
+			.draw_all_visited_floors = false,
+		};
+	}
+
+	if (mode == FloorVisibilityMode::AllVisible) {
+		return {
+			.start_floor = MAP_MAX_LAYER,
+			.end_floor = floor,
+			.draw_all_visited_floors = true,
+		};
+	}
+
+	if (floor <= GROUND_LAYER) {
+		return {
+			.start_floor = GROUND_LAYER,
+			.end_floor = 0,
+			.draw_all_visited_floors = false,
+		};
+	}
+
+	return {
+		.start_floor = std::min(MAP_MAX_LAYER, floor + 2),
+		.end_floor = GROUND_LAYER + 1,
+		.draw_all_visited_floors = false,
+	};
+}
+
+#endif

--- a/source/rendering/core/render_view.cpp
+++ b/source/rendering/core/render_view.cpp
@@ -8,6 +8,8 @@
 #include "app/definitions.h" // For TILE_SIZE, GROUND_LAYER, MAP_MAX_LAYER
 #include "ingame_preview/floor_visibility_calculator.h"
 
+#include <algorithm>
+
 void RenderView::Setup(MapCanvas* canvas, const DrawingOptions& options) {
 	canvas->MouseToMap(&mouse_map_x, &mouse_map_y);
 	canvas->GetViewBox(&view_scroll_x, &view_scroll_y, &screensize_x, &screensize_y);

--- a/source/rendering/core/render_view.cpp
+++ b/source/rendering/core/render_view.cpp
@@ -4,9 +4,9 @@
 #include "editor/editor.h"
 #include "rendering/ui/map_display.h"
 #include "rendering/core/drawing_options.h"
+#include "rendering/core/floor_visibility_mode.h"
 #include "app/definitions.h" // For TILE_SIZE, GROUND_LAYER, MAP_MAX_LAYER
 #include "ingame_preview/floor_visibility_calculator.h"
-#include <algorithm> // For std::min
 
 void RenderView::Setup(MapCanvas* canvas, const DrawingOptions& options) {
 	canvas->MouseToMap(&mouse_map_x, &mouse_map_y);
@@ -19,23 +19,18 @@ void RenderView::Setup(MapCanvas* canvas, const DrawingOptions& options) {
 	floor = canvas->GetFloor();
 	canvas->GetScreenCenter(&camera_pos.x, &camera_pos.y);
 	camera_pos.z = floor;
+	draw_all_visited_floors = false;
 
 	if (options.show_lights) {
 		IngamePreview::FloorVisibilityCalculator floor_visibility;
 		start_z = floor_visibility.CalcLastVisibleFloor(floor);
 		const Position light_origin = canvas->GetLightVisibilityOrigin().value_or(camera_pos);
 		superend_z = floor_visibility.CalcFirstVisibleFloor(canvas->editor.map, light_origin.x, light_origin.y, floor);
-	} else if (options.show_all_floors) {
-		if (floor <= GROUND_LAYER) {
-			start_z = GROUND_LAYER;
-			superend_z = 0;
-		} else {
-			start_z = std::min(MAP_MAX_LAYER, floor + 2);
-			superend_z = 8;
-		}
 	} else {
-		start_z = floor;
-		superend_z = floor;
+		const auto floor_range = BuildFloorVisibilityRange(floor, options.show_all_floors, options.floor_visibility_mode);
+		start_z = floor_range.start_floor;
+		superend_z = floor_range.end_floor;
+		draw_all_visited_floors = floor_range.draw_all_visited_floors;
 	}
 
 	end_z = floor;

--- a/source/rendering/core/render_view.h
+++ b/source/rendering/core/render_view.h
@@ -29,6 +29,7 @@ struct RenderView {
 	Position camera_pos;
 
 	int mouse_map_x, mouse_map_y;
+	bool draw_all_visited_floors = false;
 
 	glm::mat4 projectionMatrix;
 	glm::mat4 viewMatrix;

--- a/source/rendering/drawers/minimap_drawer.cpp
+++ b/source/rendering/drawers/minimap_drawer.cpp
@@ -4,6 +4,7 @@
 #include "editor/editor.h"
 #include "map/map.h"
 #include "rendering/core/map_view_math.h"
+#include "rendering/core/floor_visibility_mode.h"
 #include "rendering/core/primitive_renderer.h"
 #include "rendering/ui/map_display.h"
 #include "ui/gui.h"
@@ -26,27 +27,18 @@ namespace {
 struct MinimapFloorRenderRange {
 	int start_floor = GROUND_LAYER;
 	int current_floor = GROUND_LAYER;
+	int end_floor = GROUND_LAYER;
+	bool draw_all_visited_floors = false;
 };
 
 [[nodiscard]] MinimapFloorRenderRange getFloorRenderRange(const MinimapViewportState& viewport_state) {
-	const int current_floor = MinimapViewport::ClampFloor(viewport_state.floor);
-	if (!viewport_state.show_all_floors) {
-		return {
-			.start_floor = current_floor,
-			.current_floor = current_floor,
-		};
-	}
-
-	if (current_floor <= GROUND_LAYER) {
-		return {
-			.start_floor = GROUND_LAYER,
-			.current_floor = current_floor,
-		};
-	}
-
+	const auto mode = SanitizeFloorVisibilityMode(g_settings.getInteger(Config::FLOOR_VISIBILITY_MODE));
+	const auto range = BuildFloorVisibilityRange(viewport_state.floor, viewport_state.show_all_floors, mode);
 	return {
-		.start_floor = std::min(MAP_MAX_LAYER, current_floor + 2),
-		.current_floor = current_floor,
+		.start_floor = range.start_floor,
+		.current_floor = MinimapViewport::ClampFloor(viewport_state.floor),
+		.end_floor = range.end_floor,
+		.draw_all_visited_floors = range.draw_all_visited_floors,
 	};
 }
 
@@ -220,17 +212,15 @@ void MinimapDrawer::Draw(const wxSize& size, Editor& editor, MapCanvas& canvas, 
 		.height = std::max(1, static_cast<int>(std::ceil(visible_rect.start_y + visible_rect.height)) - static_cast<int>(std::floor(visible_rect.start_y))),
 	};
 
-	for (int floor = floor_range.start_floor; floor > floor_range.current_floor; --floor) {
+	const int last_render_floor = floor_range.draw_all_visited_floors ? floor_range.end_floor : floor_range.current_floor;
+	for (int floor = floor_range.start_floor; floor >= last_render_floor; --floor) {
+		if (floor == floor_range.current_floor && floor_range.start_floor > floor_range.current_floor) {
+			DrawFloorShade(projection, size);
+		}
+
 		renderer->flushVisible(editor.map, floor, visible_rect_pixels);
 		renderer->renderVisible(projection, 0, 0, window_width, window_height, floor, visible_rect_pixels);
 	}
-
-	if (floor_range.start_floor > floor_range.current_floor) {
-		DrawFloorShade(projection, size);
-	}
-
-	renderer->flushVisible(editor.map, floor_range.current_floor, visible_rect_pixels);
-	renderer->renderVisible(projection, 0, 0, window_width, window_height, floor_range.current_floor, visible_rect_pixels);
 	if (options.drawBoundsBorder) {
 		DrawMapBoundsBorder(projection, size, editor, visible_rect);
 	}

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -399,7 +399,7 @@ void MapDrawer::DrawMap() {
 			shade_drawer->draw(*sprite_batch, view, options);
 		}
 
-		if (map_z >= view.end_z) {
+		if (view.draw_all_visited_floors || map_z >= view.end_z) {
 			DrawMapLayer(*sprite_batch, map_z, live_client);
 		} else if (options.isDrawLight()) {
 			DrawMapLayer(hidden_floor_light_batch, map_z, live_client, true);


### PR DESCRIPTION
Introduced 'All Visible' floor visibility mode and refactored visibility range logic into a shared utility. This allows rendering all floors below the active floor regardless of client visibility constraints.
- `source/CMakeLists.txt` — added floor_visibility_mode source and header files
- `source/app/preferences/editor_page.cpp` — implemented floor visibility mode UI and refresh logic
- `source/app/preferences/editor_page.h` — added wxChoice member for visibility mode selection
- `source/app/settings.cpp` — added FLOOR_VISIBILITY_MODE to persistence logic
- `source/app/settings.h` — added FLOOR_VISIBILITY_MODE key to Config enum
- `source/editor/action.cpp` — refactored commit/undo to use specialized tile update helpers
- `source/editor/selection.cpp` — switched to updateSelectionState for optimized selection updates
- `source/map/tile.h` — [minor] replaced forward declarations with tile_operations.h include
- `source/map/tile_operations.cpp` — implemented updateSelectionState and removed redundant comment
- `source/map/tile_operations.h` — added updateSelectionState function declaration
- `source/rendering/core/drawing_options.cpp` — synchronized visibility mode with settings
- `source/rendering/core/drawing_options.h` — added FloorVisibilityMode to drawing state
- `source/rendering/core/floor_visibility_mode.cpp` — added static assertion tests for visibility range logic
- `source/rendering/core/floor_visibility_mode.h` — defined visibility modes and encapsulated range calculation logic
- `source/rendering/core/render_view.cpp` — integrated BuildFloorVisibilityRange and support for drawing all visited floors
- `source/rendering/core/render_view.h` — added draw_all_visited_floors flag to view state
- `source/rendering/drawers/minimap_drawer.cpp` — updated minimap to use shared floor visibility logic
- `source/rendering/map_drawer.cpp` — updated draw loop to support rendering all floors below active layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Floor Visibility Mode" editor preference with two modes ("Client visible" and "All visible") and persisted default.

* **Improvements**
  * Rendering and minimap now respect the chosen floor-visibility mode and a new "draw all visited floors" toggle.
  * Editor applies the setting and refreshes view/minimap only when the value actually changes.

* **Bug Fixes**
  * Selection visuals updated more precisely to avoid incorrect full-tile refreshes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/karolak6612/remeres-map-editor-redux/pull/1024)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->