### PR TITLE
fix(palette): sort RAW items by server ID

### DIFF
--- a/source/game/materials.cpp
+++ b/source/game/materials.cpp
@@ -262,8 +262,9 @@ void Materials::createOtherTileset() {
 		tilesets["NPCs"] = npc_tileset;
 	}
 
-	// There should really be an iterator to do this
-	for (ServerItemId id : g_item_definitions.allIds()) {
+	const uint32_t max_item_id = g_item_definitions.maxServerId();
+	for (uint32_t raw_id = 0; raw_id <= max_item_id; ++raw_id) {
+		const ServerItemId id = static_cast<ServerItemId>(raw_id);
 		const auto definition = g_item_definitions.get(id);
 		if (!definition) {
 			continue;


### PR DESCRIPTION
Fixes RAW palette item ordering by iterating server item IDs numerically when building the automatic `Others` tileset.

The regression was caused by using `allIds()`, whose order follows the item-definition load order after the storage refactor.

Manual tileset ordering remains unchanged.

Validation:
- Release compilation: 0 errors
- Release linking and startup smoke test passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tileset generation to account for the complete range of server item IDs.
  * Missing item definitions continue to be safely skipped, preventing incomplete or invalid tilesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->